### PR TITLE
Fix broken testcase for metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+ * Fixed broken testcase for `/metrics` endpoint
+
 ## [0.1.0] 2022-10-02
 
 ### Changed

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -74,8 +74,9 @@ async fn metrics() -> Result<()> {
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = hyper::body::to_bytes(response.into_body()).await?;
-    assert!(body.starts_with(
-        b"# TYPE http_requests_total counter
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(dbg!(body).contains(
+        "# TYPE http_requests_total counter
 http_requests_total{method=\"GET\",path=\"/metrics\",status=\"200\"}"
     ));
 


### PR DESCRIPTION
Use `String::contains` instead of `Bytes::starts_with`