### PR TITLE
Ensure unique names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,8 @@ dependencies = [
  "metrics-exporter-prometheus",
  "mime",
  "petname",
+ "quickcheck",
+ "quickcheck_macros",
  "rand",
  "ructe",
  "serde",
@@ -886,6 +888,26 @@ dependencies = [
  "wasi 0.10.2+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 
 [dev-dependencies]
+quickcheck = { version = "1.0.3", default-features = false }
+quickcheck_macros = "1.0.0"
 tower = { version = "0.4.13", features = ["util"] }
 
 [build-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use std::{
+    collections::HashSet,
     fmt,
     future::ready,
     iter::repeat_with,
@@ -69,61 +70,69 @@ where
     }
 }
 
-fn generate_names(words_per_name: u8, separator: &str, number_of_names: usize) -> Vec<String> {
-    // first generate names with a non-empty separator so we can capitalize the first letters
-    static TEMP_SEPARATOR: &str = "-";
-    let petnames = Petnames::medium();
-    let mut rng = rand::thread_rng();
-    repeat_with(|| {
-        petnames
-            .generate(&mut rng, words_per_name, TEMP_SEPARATOR)
-            .split(TEMP_SEPARATOR)
-            .map(|name| {
-                // capitalize first letters
-                name.chars().fold(
-                    (String::with_capacity(name.len()), true),
-                    |(mut builder, first), next| {
-                        builder.push(if first {
-                            next.to_ascii_uppercase()
-                        } else {
-                            next
-                        });
-                        (builder, false)
-                    },
-                )
+fn capitalize_first_letters(input: &str) -> String {
+    input
+        .chars()
+        .fold(
+            (String::with_capacity(input.len()), true),
+            |(mut builder, first), next| {
+                builder.push(if first {
+                    next.to_ascii_uppercase()
+                } else {
+                    next
+                });
+                (builder, false)
+            },
+        )
+        .0
+}
+
+/// Generate random usernames. Since `petnames::iter_non_repeating` does currently not work as
+/// expected, the names are collected into a `HashSet` to get unique names. The function calls
+/// itself recursively until the set contains exactly `number_of_names` names.
+pub(crate) fn generate_names(
+    mut set: HashSet<String>,
+    words_per_name: NonZeroU8,
+    separator: &str,
+    number_of_names: NonZeroUsize,
+) -> HashSet<String> {
+    // exit condition for recursion: `number_of_names` unique names were generated
+    if set.len() >= number_of_names.get() {
+        set
+    } else {
+        // first generate names with a non-empty separator so we can split and capitalize the first letters
+        static TEMP_SEPARATOR: &str = "-";
+        let petnames = Petnames::medium();
+        let mut rng = rand::thread_rng();
+        set.extend(
+            repeat_with(|| {
+                petnames
+                    .generate(&mut rng, words_per_name.get(), TEMP_SEPARATOR)
+                    .split(TEMP_SEPARATOR)
+                    .map(capitalize_first_letters)
+                    .collect::<Vec<_>>()
+                    // use the user-supplied separator to join the capitalized parts of the username
+                    .join(separator)
             })
-            .map(|(name, _)| name)
-            .collect::<Vec<_>>()
-            .join(separator)
-    })
-    .take(number_of_names)
-    .collect()
+            // only generate the missing amount of names to get exactly `number_of_names` entries
+            .take(number_of_names.get() - set.len()),
+        );
+        // recurse
+        generate_names(set, words_per_name, separator, number_of_names)
+    }
 
     // TODO: wait for https://github.com/allenap/rust-petname/issues/61 to be fixed
     // TODO: the solution above might return non-unique names (https://github.com/vbrandl/petnames-generator/issues/1)
     // let names: Vec<_> = petnames
-    //     .iter_non_repeating(&mut rng, words, DEFAULT_SEPARATOR)
+    //     .iter_non_repeating(&mut rng, words_per_name, TEMP_SEPARATOR)
     //     .map(|name| {
     //         name.split(DEFAULT_SEPARATOR)
-    //             .map(|n| {
-    //                 // capitalize first letters
-    //                 n.chars().fold(
-    //                     (String::with_capacity(n.len()), true),
-    //                     |(mut builder, first), next| {
-    //                         builder.push(if first {
-    //                             next.to_ascii_uppercase()
-    //                         } else {
-    //                             next
-    //                         });
-    //                         (builder, false)
-    //                     },
-    //                 )
-    //             })
-    //             .map(|(name, _)| name)
+    //             .map(capitalize_first_letters)
     //             .collect::<Vec<_>>()
+    //              // use the user-supplied separator to join the capitalized parts of the username
     //             .join(separator)
     //     })
-    //     .take(names)
+    //     .take(number_of_names)
     //     .collect();
 }
 
@@ -141,7 +150,7 @@ async fn root(query: Option<Query<GenerateQuery>>) -> Response {
         let number_of_names = number_of_names
             .map(NonZeroUsize::from)
             .unwrap_or(DEFAULT_NUMBER_OF_NAMES);
-        let names = generate_names(words_per_name, separator, number_of_names);
+        let names = generate_names(HashSet::new(), words_per_name, separator, number_of_names);
 
         render!(templates::index, &names, query, statics::VERSION_INFO).into_response()
     } else {

--- a/src/statics.rs
+++ b/src/statics.rs
@@ -1,3 +1,5 @@
+use std::num::{NonZeroU8, NonZeroUsize};
+
 pub struct VersionInfo<'a> {
     pub commit: &'a str,
     pub semver: &'a str,
@@ -8,6 +10,6 @@ pub const VERSION_INFO: VersionInfo = VersionInfo {
     semver: env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"),
 };
 
-pub static DEFAULT_SEPARATOR: &str = "";
-pub static DEFAULT_WORDS_PER_NAME: u8 = 2;
-pub static DEFAULT_NUMBER_OF_NAMES: usize = 6;
+pub const DEFAULT_SEPARATOR: &str = "";
+pub const DEFAULT_WORDS_PER_NAME: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(2) };
+pub const DEFAULT_NUMBER_OF_NAMES: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(6) };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,10 @@
-use super::*;
 use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
 use tower::{Service, ServiceExt};
+
+use super::*;
 
 #[tokio::test]
 async fn root() -> Result<()> {
@@ -19,13 +20,13 @@ async fn root() -> Result<()> {
 }
 
 #[tokio::test]
-async fn bad_request() -> Result<()> {
+async fn reject_negative() -> Result<()> {
     let mut app = app();
 
     let response = app
         .call(
             Request::builder()
-                .uri("/?words_per_name=-1")
+                .uri("/?words_per_name=-2")
                 .body(Body::empty())?,
         )
         .await?;
@@ -36,6 +37,33 @@ async fn bad_request() -> Result<()> {
         .call(
             Request::builder()
                 .uri("/?number_of_names=-1")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn reject_zero() -> Result<()> {
+    let mut app = app();
+
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/?words_per_name=0")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/?number_of_names=0")
                 .body(Body::empty())?,
         )
         .await?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,7 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use quickcheck_macros::quickcheck;
 use tower::{Service, ServiceExt};
 
 use super::*;
@@ -133,4 +134,19 @@ async fn metrics() -> Result<()> {
     assert!(body.contains("http_requests_total{method=\"GET\",path=\"/metrics\",status=\"200\"}"));
 
     Ok(())
+}
+
+#[quickcheck]
+fn generated_names_are_unique(number_of_names: NonZeroU8) {
+    let number_of_names = NonZeroUsize::from(number_of_names);
+    assert_eq!(
+        generate_names(
+            HashSet::new(),
+            statics::DEFAULT_WORDS_PER_NAME,
+            statics::DEFAULT_SEPARATOR,
+            number_of_names
+        )
+        .len(),
+        number_of_names.get()
+    );
 }

--- a/templates/index.rs.html
+++ b/templates/index.rs.html
@@ -1,5 +1,6 @@
 @use super::base;
 @use std::{
+    collections::HashSet,
     num::NonZeroU8,
 };
 @use crate::{
@@ -7,7 +8,7 @@
     statics::{VersionInfo, DEFAULT_NUMBER_OF_NAMES, DEFAULT_SEPARATOR, DEFAULT_WORDS_PER_NAME}
 };
 
-@(names: &[String], query: &GenerateQuery, version_info: VersionInfo)
+@(names: &HashSet<String>, query: &GenerateQuery, version_info: VersionInfo)
 
 @:base("Petnames", "Petnames", {
 <section>

--- a/templates/index.rs.html
+++ b/templates/index.rs.html
@@ -1,4 +1,7 @@
 @use super::base;
+@use std::{
+    num::NonZeroU8,
+};
 @use crate::{
     GenerateQuery,
     statics::{VersionInfo, DEFAULT_NUMBER_OF_NAMES, DEFAULT_SEPARATOR, DEFAULT_WORDS_PER_NAME}
@@ -19,10 +22,10 @@
         <input type="text" id="separator" name="separator" value="@(query.separator.as_deref().unwrap_or(""))" placeholder="@(DEFAULT_SEPARATOR)">
 
         <label for="words_per_name">Words per Name</label>
-        <input type="number" id="words_per_name" name="words_per_name" value="@(query.words_per_name.as_ref().map(u8::to_string).as_deref().unwrap_or(""))" placeholder="@(DEFAULT_WORDS_PER_NAME)">
+        <input type="number" id="words_per_name" name="words_per_name" value="@(query.words_per_name.as_ref().map(NonZeroU8::to_string).as_deref().unwrap_or(""))" placeholder="@(DEFAULT_WORDS_PER_NAME)">
 
         <label for="number_of_names">Number of Names</label>
-        <input type="number" id="number_of_names" name="number_of_names" value="@(query.number_of_names.as_ref().map(u8::to_string).as_deref().unwrap_or(""))" placeholder="@(DEFAULT_NUMBER_OF_NAMES)">
+        <input type="number" id="number_of_names" name="number_of_names" value="@(query.number_of_names.as_ref().map(NonZeroU8::to_string).as_deref().unwrap_or(""))" placeholder="@(DEFAULT_NUMBER_OF_NAMES)">
 
         <button type="submit">Generate</button>
     </form>


### PR DESCRIPTION
By collecting the generated names into a `HashSet` (that ensures unique entries) and recursively calling the generator until the expected amount of words was generated, uniqueness of the generated names can be ensured.

Trying to generate `n > 1` names of length `0` would result in a infinite loop, since there is only one possible name of length `0`: `""`. By using `NonZero*` numeric types, we can ensure, the recursion will always terminate.

This temporarily solves #1 until upstream is fixed.