### PR TITLE
Clean repository when building the deployment image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Fixed
+
+ * [#21]: Clean git repository for deployment image ([#22])
+
+
+[#21]: https://github.com/vbrandl/petnames-generator/pull/21
+[#22]: https://github.com/vbrandl/petnames-generator/pull/22
+
+
 ## [0.6.0] 2022-10-03
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,13 @@ COPY . .
 
 RUN touch src/main.rs && touch src/build.rs
 
+# TODO, HACK: This is a temporary workaround for
+# https://github.com/vbrandl/petnames-generator/issues/21
+# `flyctl deploy` deletes or ignores `fly.toml` when building the image, this
+# causes the repo to be dirty at build time which breaks the version info in
+# the footer
+RUN git checkout fly.toml
+
 # Build (install) the actual binaries
 RUN cargo build --release
 


### PR DESCRIPTION
This is a temporary fix for https://github.com/vbrandl/petnames-generator/issues/21